### PR TITLE
use union for data-values

### DIFF
--- a/include/libKitsuneCommon/common_items/data_items.h
+++ b/include/libKitsuneCommon/common_items/data_items.h
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <string>
+#include <string.h>
 #include <vector>
 #include <map>
 
@@ -128,9 +129,14 @@ public:
                          const uint32_t=0);
 
     // content
-    std::string m_stringValue = "";
-    int m_intValue = 0;
-    float m_floatValue = 0.0f;
+    union DataValueContent
+    {
+        char* stringValue;
+        int intValue;
+        float floatValue;
+    };
+
+    DataValueContent m_content;
 };
 
 //===================================================================

--- a/src/common_items/data_items.cpp
+++ b/src/common_items/data_items.cpp
@@ -121,17 +121,17 @@ DataItem::getString() const
     if(m_valueType == STRING_TYPE)
     {
         const DataValue* value = dynamic_cast<const DataValue*>(this);
-        return value->m_stringValue;
+        return std::string(value->m_content.stringValue);
     }
     if(m_valueType == INT_TYPE)
     {
         const DataValue* value = dynamic_cast<const DataValue*>(this);
-        return std::to_string(value->m_intValue);;
+        return std::to_string(value->m_content.intValue);
     }
     if(m_valueType == FLOAT_TYPE)
     {
         const DataValue* value = dynamic_cast<const DataValue*>(this);
-        return std::to_string(value->m_floatValue);;
+        return std::to_string(value->m_content.floatValue);
     }
     return "";
 }
@@ -147,7 +147,7 @@ DataItem::getInt()
     if(m_valueType == INT_TYPE)
     {
         DataValue* value = dynamic_cast<DataValue*>(this);
-        return value->m_intValue;
+        return value->m_content.intValue;
     }
     return 0;
 }
@@ -164,7 +164,7 @@ DataItem::getFloat()
     if(m_valueType == FLOAT_TYPE)
     {
         DataValue* value = dynamic_cast<DataValue*>(this);
-        return value->m_floatValue;
+        return value->m_content.floatValue;
     }
     return 0.0f;
 }
@@ -198,6 +198,9 @@ DataValue::DataValue()
 {
     m_type = VALUE_TYPE;
     m_valueType = STRING_TYPE;
+
+    m_content.stringValue = new char[1];
+    m_content.stringValue[0] = '\0';
 }
 
 /**
@@ -207,7 +210,10 @@ DataValue::DataValue(const std::string &text)
 {
     m_type = VALUE_TYPE;
     m_valueType = STRING_TYPE;
-    m_stringValue = text;
+
+    m_content.stringValue = new char[text.size()+1];
+    memcpy(m_content.stringValue, text.c_str(), text.size());
+    m_content.stringValue[text.size()] = '\0';
 }
 
 /**
@@ -217,7 +223,7 @@ DataValue::DataValue(const int value)
 {
     m_type = VALUE_TYPE;
     m_valueType = INT_TYPE;
-    m_intValue = value;
+    m_content.intValue = value;
 }
 
 /**
@@ -227,7 +233,7 @@ DataValue::DataValue(const float value)
 {
     m_type = VALUE_TYPE;
     m_valueType = FLOAT_TYPE;
-    m_floatValue = value;
+    m_content.floatValue = value;
 }
 
 /**
@@ -319,13 +325,13 @@ DataValue::copy()
 {
     DataValue* tempItem = nullptr;
     if(m_valueType == STRING_TYPE) {
-        tempItem = new DataValue(m_stringValue);
+        tempItem = new DataValue(std::string(m_content.stringValue));
     }
     if(m_valueType == INT_TYPE) {
-        tempItem = new DataValue(m_intValue);
+        tempItem = new DataValue(m_content.intValue);
     }
     if(m_valueType == FLOAT_TYPE) {
-        tempItem = new DataValue(m_floatValue);
+        tempItem = new DataValue(m_content.floatValue);
     }
     return tempItem;
 }
@@ -346,14 +352,14 @@ DataValue::toString(const bool,
     if(m_valueType == STRING_TYPE)
     {
         output->append("\"");
-        output->append(m_stringValue);
+        output->append(std::string(m_content.stringValue));
         output->append("\"");
     }
     if(m_valueType == INT_TYPE) {
-        output->append(std::to_string(m_intValue));
+        output->append(std::to_string(m_content.intValue));
     }
     if(m_valueType == FLOAT_TYPE) {
-        output->append(std::to_string(m_floatValue));
+        output->append(std::to_string(m_content.floatValue));
     }
 
     return out;
@@ -365,11 +371,16 @@ DataValue::toString(const bool,
 void
 DataValue::setValue(const std::string &item)
 {
+    if(m_valueType == STRING_TYPE) {
+        delete m_content.stringValue;
+    }
+
     m_type = VALUE_TYPE;
     m_valueType = STRING_TYPE;
-    m_intValue = 0;
-    m_floatValue = 0.0f;
-    m_stringValue = item;
+
+    m_content.stringValue = new char[item.size()+1];
+    memcpy(m_content.stringValue, item.c_str(), item.size());
+    m_content.stringValue[item.size()] = '\0';
 }
 
 /**
@@ -378,11 +389,14 @@ DataValue::setValue(const std::string &item)
 void
 DataValue::setValue(const int &item)
 {
+    if(m_valueType == STRING_TYPE) {
+        delete m_content.stringValue;
+    }
+
     m_type = VALUE_TYPE;
     m_valueType = INT_TYPE;
-    m_stringValue = "";
-    m_floatValue = 0.0f;
-    m_intValue = item;
+
+    m_content.intValue = item;
 }
 
 /**
@@ -391,11 +405,14 @@ DataValue::setValue(const int &item)
 void
 DataValue::setValue(const float &item)
 {
+    if(m_valueType == STRING_TYPE) {
+        delete m_content.stringValue;
+    }
+
     m_type = VALUE_TYPE;
     m_valueType = FLOAT_TYPE;
-    m_stringValue = "";
-    m_intValue = 0;
-    m_floatValue = item;
+
+    m_content.floatValue = item;
 }
 
 //===================================================================

--- a/tests/libKitsuneCommon/common_items/data_items_DataValue_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataValue_test.cpp
@@ -101,19 +101,21 @@ DataItems_DataValue_Test::copy_test()
 
     // default-value
     DataValue* defaultValueCopy = dynamic_cast<DataValue*>(defaultValue.copy());
-    UNITTEST(defaultValue.m_stringValue, defaultValueCopy->m_stringValue);
+    UNITTEST(std::string(defaultValue.m_content.stringValue),
+             std::string(defaultValueCopy->m_content.stringValue));
 
     // string-value
     DataValue* stringValueCopy = dynamic_cast<DataValue*>(stringValue.copy());
-    UNITTEST(stringValue.m_stringValue, stringValueCopy->m_stringValue);
+    UNITTEST(std::string(stringValue.m_content.stringValue),
+             std::string(stringValueCopy->m_content.stringValue));
 
     // int-value
     DataValue* intValueCopy = dynamic_cast<DataValue*>(intValue.copy());
-    UNITTEST(intValue.m_intValue, intValueCopy->m_intValue);
+    UNITTEST(intValue.m_content.intValue, intValueCopy->m_content.intValue);
 
     // float-value
     DataValue* floatValueCopy = dynamic_cast<DataValue*>(floatValue.copy());
-    UNITTEST(floatValue.m_floatValue, floatValueCopy->m_floatValue);
+    UNITTEST(floatValue.m_content.floatValue, floatValueCopy->m_content.floatValue);
 
     // cleanup
     delete defaultValueCopy;
@@ -246,23 +248,17 @@ DataItems_DataValue_Test::setValue_test()
     // string-value
     defaultValue.setValue("test");
     UNITTEST(defaultValue.getValueType(), DataItem::STRING_TYPE);
-    UNITTEST(defaultValue.m_stringValue, "test");
-    UNITTEST(defaultValue.m_intValue, 0);
-    UNITTEST(defaultValue.m_floatValue, 0.0f);
+    UNITTEST(std::string(defaultValue.m_content.stringValue), "test");
 
     // int-value
     defaultValue.setValue(42);
     UNITTEST(defaultValue.getValueType(), DataItem::INT_TYPE);
-    UNITTEST(defaultValue.m_stringValue, "");
-    UNITTEST(defaultValue.m_intValue, 42);
-    UNITTEST(defaultValue.m_floatValue, 0.0f);
+    UNITTEST(defaultValue.m_content.intValue, 42);
 
     // float-value
     defaultValue.setValue(42.5f);
     UNITTEST(defaultValue.getValueType(), DataItem::FLOAT_TYPE);
-    UNITTEST(defaultValue.m_stringValue, "");
-    UNITTEST(defaultValue.m_intValue, 0);
-    UNITTEST(defaultValue.m_floatValue, 42.5f);
+    UNITTEST(defaultValue.m_content.floatValue, 42.5f);
 }
 
 }  // namespace Common


### PR DESCRIPTION
To avoid unnecessary memory consumption, the simple values inside the
DataValue-class were merged into a union. To make the possible, the
internal string-object was replace by a char-pointer.