### PR TITLE
fix data-values

### DIFF
--- a/include/libKitsuneCommon/common_items/data_items.h
+++ b/include/libKitsuneCommon/common_items/data_items.h
@@ -102,6 +102,7 @@ class DataValue : public DataItem
 {
 public:
     DataValue();
+    DataValue(const char* text);
     DataValue(const std::string &text);
     DataValue(const int value);
     DataValue(const float value);
@@ -110,6 +111,7 @@ public:
 
     // setter
     dataValueTypes getValueType();
+    void setValue(const char *item);
     void setValue(const std::string &item);
     void setValue(const int &item);
     void setValue(const float &item);

--- a/src/common_items/data_items.cpp
+++ b/src/common_items/data_items.cpp
@@ -210,6 +210,21 @@ DataValue::DataValue()
 }
 
 /**
+ * @brief data-value for char-arrays
+ */
+DataValue::DataValue(const char *text)
+{
+    m_type = VALUE_TYPE;
+    m_valueType = STRING_TYPE;
+
+    size_t len = strlen(text);
+
+    m_content.stringValue = new char[len+1];
+    strncpy(m_content.stringValue, text, len);
+    m_content.stringValue[len] = '\0';
+}
+
+/**
  * @brief data-value for strings
  */
 DataValue::DataValue(const std::string &text)
@@ -392,6 +407,26 @@ DataValue::toString(const bool,
     }
 
     return out;
+}
+
+/**
+ * @brief writes a new string into the data-value
+ */
+void
+DataValue::setValue(const char *item)
+{
+    if(m_valueType == STRING_TYPE) {
+        delete m_content.stringValue;
+    }
+
+    m_type = VALUE_TYPE;
+    m_valueType = STRING_TYPE;
+
+    size_t len = strlen(item);
+
+    m_content.stringValue = new char[len+1];
+    strncpy(m_content.stringValue, item, len);
+    m_content.stringValue[len] = '\0';
 }
 
 /**

--- a/tests/libKitsuneCommon/common_items/data_items_DataArray_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataArray_test.cpp
@@ -40,7 +40,7 @@ DataItems_DataArray_Test::append_test()
 {
     DataArray array;
     DataValue defaultValue;
-    DataValue stringValue(std::string("test"));
+    DataValue stringValue("test");
     DataValue intValue(42);
     DataValue floatValue(42.5f);
 
@@ -213,7 +213,7 @@ DataItems_DataArray_Test::initTestArray()
 {
     DataArray array;
     DataValue defaultValue;
-    DataValue stringValue(std::string("test"));
+    DataValue stringValue("test");
     DataValue intValue(42);
     DataValue floatValue(42.5f);
 

--- a/tests/libKitsuneCommon/common_items/data_items_DataMap_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataMap_test.cpp
@@ -197,7 +197,7 @@ DataItems_DataMap_Test::insert_test()
 {
     DataMap object;
     DataValue defaultValue;
-    DataValue stringValue(std::string("test"));
+    DataValue stringValue("test");
     DataValue intValue(42);
     DataValue floatValue(42.5f);
 
@@ -277,7 +277,7 @@ DataItems_DataMap_Test::initTestObject()
 {
     DataMap object;
     DataValue defaultValue;
-    DataValue stringValue(std::string("test"));
+    DataValue stringValue("test");
     DataValue intValue(42);
     DataValue floatValue(42.5f);
 

--- a/tests/libKitsuneCommon/common_items/data_items_DataValue_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataValue_test.cpp
@@ -95,7 +95,7 @@ DataItems_DataValue_Test::copy_test()
 {
     // init
     DataValue defaultValue;
-    DataValue stringValue(std::string("test"));
+    DataValue stringValue("test");
     DataValue intValue(42);
     DataValue floatValue(42.5f);
     DataValue boolValue(true);
@@ -136,7 +136,7 @@ void
 DataItems_DataValue_Test::toString_test()
 {
     DataValue defaultValue;
-    DataValue stringValue(std::string("test"));
+    DataValue stringValue("test");
     DataValue intValue(42);
     DataValue floatValue(42.5f);
     DataValue boolValue(true);
@@ -155,7 +155,7 @@ void
 DataItems_DataValue_Test::getType_test()
 {
     DataValue defaultValue;
-    DataValue stringValue(std::string("test"));
+    DataValue stringValue("test");
     DataValue intValue(42);
     DataValue floatValue(42.5f);
     DataValue boolValue(true);
@@ -204,7 +204,7 @@ void
 DataItems_DataValue_Test::getString_getInt_getFloat_getBool_test()
 {
     DataValue defaultValue;
-    DataValue stringValue(std::string("test"));
+    DataValue stringValue("test");
     DataValue intValue(42);
     DataValue floatValue(42.5f);
     DataValue boolValue(true);
@@ -247,7 +247,7 @@ void
 DataItems_DataValue_Test::getValueType_test()
 {
     DataValue defaultValue;
-    DataValue stringValue(std::string("test"));
+    DataValue stringValue("test");
     DataValue intValue(42);
     DataValue floatValue(42.5f);
     DataValue boolValue(true);
@@ -268,7 +268,7 @@ DataItems_DataValue_Test::setValue_test()
     DataValue defaultValue;
 
     // string-value
-    defaultValue.setValue(std::string("test"));
+    defaultValue.setValue("test");
     UNITTEST(defaultValue.getValueType(), DataItem::STRING_TYPE);
     UNITTEST(std::string(defaultValue.m_content.stringValue), "test");
 


### PR DESCRIPTION
added a constructor and a setter, which accept char-arrays to avoid the conflict
with the overloaded constructor/setter of the bool-value.