### PR TITLE
update toString-method

### DIFF
--- a/include/libKitsuneCommon/common_items/data_items.h
+++ b/include/libKitsuneCommon/common_items/data_items.h
@@ -66,7 +66,7 @@ public:
     // output
     virtual DataItem* copy() = 0;
     virtual std::string toString(bool indent=false,
-                                 std::string *output=nullptr,
+                                 std::string* output=nullptr,
                                  uint32_t step=0) = 0;
 
     // checker
@@ -74,6 +74,10 @@ public:
     bool isValue() const;
     bool isMap() const;
     bool isArray() const;
+    bool isStringValue() const;
+    bool isIntValue() const;
+    bool isFloatValue() const;
+    bool isBoolValue() const;
 
     // converter
     DataArray* toArray();

--- a/src/common_items/data_items.cpp
+++ b/src/common_items/data_items.cpp
@@ -74,6 +74,54 @@ DataItem::isArray() const
 }
 
 /**
+ * @brief check if DataItem is a String-Value
+ */
+bool
+DataItem::isStringValue() const
+{
+    if(m_valueType == STRING_TYPE) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @brief check if DataItem is a int-Value
+ */
+bool
+DataItem::isIntValue() const
+{
+    if(m_valueType == INT_TYPE) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @brief check if DataItem is a float-Value
+ */
+bool
+DataItem::isFloatValue() const
+{
+    if(m_valueType == FLOAT_TYPE) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @brief check if DataItem is a bool-Value
+ */
+bool
+DataItem::isBoolValue() const
+{
+    if(m_valueType == BOOL_TYPE) {
+        return true;
+    }
+    return false;
+}
+
+/**
  * @brief convert to a DataArray
  */
 DataArray*
@@ -385,14 +433,13 @@ DataValue::toString(const bool,
 
     if(m_valueType == STRING_TYPE)
     {
-        output->append("\"");
         output->append(std::string(m_content.stringValue));
-        output->append("\"");
     }
 
     if(m_valueType == INT_TYPE) {
         output->append(std::to_string(m_content.intValue));
     }
+
     if(m_valueType == FLOAT_TYPE) {
         output->append(std::to_string(m_content.floatValue));
     }
@@ -761,6 +808,7 @@ DataMap::toString(const bool indent,
         output = &out;
     }
 
+    // begin map
     bool firstPring = false;
     output->append("{");
 
@@ -780,26 +828,41 @@ DataMap::toString(const bool indent,
             }
             firstPring = true;
 
+            // add key
             addIndent(output, indent, level+1);
-
-            output->append("\"");
             output->append(it->first);
-            output->append("\"");
+
             output->append(":");
 
             if(indent == true) {
                 output->append(" ");
             }
 
-            // TODO: add unit-tests for nullptr-case
-            if(it->second == nullptr) {
+            // add value
+            if(it->second == nullptr)
+            {
+                // TODO: add unit-tests for nullptr-case
                 output->append("NULL");
-            } else {
+            }
+            else
+            {
+                // if value is string-item, then set quotes
+                if(it->second->isStringValue()) {
+                    output->append("\"");
+                }
+
+                // convert value of item into stirng
                 it->second->toString(indent, output, level+1);
+
+                // if value is string-item, then set quotes
+                if(it->second->isStringValue()) {
+                    output->append("\"");
+                }
             }
         }
     }
 
+    // close map
     addIndent(output, indent, level);
     output->append("}");
 
@@ -984,25 +1047,40 @@ DataArray::toString(const bool indent,
         output = &out;
     }
 
+    // begin array
     output->append("[");
     addIndent(output, indent, level+1);
 
     std::vector<DataItem*>::iterator it;
     for(it = m_array.begin(); it != m_array.end(); it++)
     {
+        // separate items of the array with comma
         if(it != m_array.begin())
         {
             output->append(",");
             addIndent(output, indent, level+1);
         }
 
+        // check value
         if((*it) == nullptr) {
             continue;
         }
 
+        // if value is string-item, then set quotes
+        if((*it)->isStringValue()) {
+            output->append("\"");
+        }
+
+        // convert value of item into stirng
         (*it)->toString(indent, output, level+1);
+
+        // if value is string-item, then set quotes
+        if((*it)->isStringValue()) {
+            output->append("\"");
+        }
     }
 
+    // close array
     addIndent(output, indent, level);
     output->append("]");
 

--- a/tests/libKitsuneCommon/common_items/data_items_DataArray_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataArray_test.cpp
@@ -60,7 +60,7 @@ DataItems_DataArray_Test::operator_test()
 {
     DataArray array = initTestArray();
 
-    UNITTEST(array[1]->toString(), "\"test\"");
+    UNITTEST(array[1]->toString(), "test");
 
     // negative tests
     bool isNullptr = array[10] == nullptr;

--- a/tests/libKitsuneCommon/common_items/data_items_DataMap_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataMap_test.cpp
@@ -125,14 +125,14 @@ DataItems_DataMap_Test::toString_test()
 {
     DataMap object = initTestObject();
 
-    std::string compare = "{\"asdf\":\"test\",\"hmm\":42,\"poi\":\"\",\"xyz\":42.500000}";
+    std::string compare = "{asdf:\"test\",hmm:42,poi:\"\",xyz:42.500000}";
     UNITTEST(object.toString(), compare);
 
     compare = "{\n"
-              "    \"asdf\": \"test\",\n"
-              "    \"hmm\": 42,\n"
-              "    \"poi\": \"\",\n"
-              "    \"xyz\": 42.500000\n"
+              "    asdf: \"test\",\n"
+              "    hmm: 42,\n"
+              "    poi: \"\",\n"
+              "    xyz: 42.500000\n"
               "}";
     UNITTEST(object.toString(true), compare);
 }
@@ -246,9 +246,9 @@ DataItems_DataMap_Test::getValues_test()
 
     std::vector<DataItem*> values = object.getValues();
     UNITTEST(values.size(), 4);
-    UNITTEST(values.at(0)->toString(), "\"test\"");
+    UNITTEST(values.at(0)->toString(), "test");
     UNITTEST(values.at(1)->toString(), "42");
-    UNITTEST(values.at(2)->toString(), "\"\"");
+    UNITTEST(values.at(2)->toString(), "");
     UNITTEST(values.at(3)->toString(), "42.500000");
 }
 

--- a/tests/libKitsuneCommon/common_items/data_items_DataValue_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataValue_test.cpp
@@ -141,8 +141,8 @@ DataItems_DataValue_Test::toString_test()
     DataValue floatValue(42.5f);
     DataValue boolValue(true);
 
-    UNITTEST(defaultValue.toString(), "\"\"");
-    UNITTEST(stringValue.toString(), "\"test\"");
+    UNITTEST(defaultValue.toString(), "");
+    UNITTEST(stringValue.toString(), "test");
     UNITTEST(intValue.toString(), "42");
     UNITTEST(floatValue.toString(), "42.500000");
     UNITTEST(boolValue.toString(), "true");


### PR DESCRIPTION
Now string-values only get quotes when their toString-method is called by the
toString-method of DataMap or DataArray. That make more sense and make it easier
to handle.