### PR TITLE
fix toString-output

### DIFF
--- a/include/libKitsuneCommon/common_items/data_items.h
+++ b/include/libKitsuneCommon/common_items/data_items.h
@@ -204,7 +204,7 @@ public:
     ~DataArray();
 
     // add
-    bool append(DataItem* item);
+    void append(DataItem* item);
 
     // getter
     DataItem* operator[](const std::string key);

--- a/src/common_items/data_items.cpp
+++ b/src/common_items/data_items.cpp
@@ -790,7 +790,11 @@ DataMap::copy()
     std::map<std::string, DataItem*>::iterator it;
     for(it = m_map.begin(); it != m_map.end(); it++)
     {
-        tempItem->insert(it->first, it->second->copy());
+        if(it->second == nullptr) {
+            tempItem->insert(it->first, nullptr);
+        } else {
+            tempItem->insert(it->first, it->second->copy());
+        }
     }
     return tempItem;
 }
@@ -809,55 +813,47 @@ DataMap::toString(const bool indent,
     }
 
     // begin map
-    bool firstPring = false;
+    bool firstRun = false;
     output->append("{");
 
-    for(uint8_t typeCounter = 1; typeCounter < 6; typeCounter++)
+    std::map<std::string, DataItem*>::iterator it;
+    for(it = m_map.begin(); it != m_map.end(); it++)
     {
-        std::map<std::string, DataItem*>::iterator it;
-        for(it = m_map.begin(); it != m_map.end(); it++)
+        if(firstRun) {
+            output->append(",");
+        }
+        firstRun = true;
+
+        // add key
+        addIndent(output, indent, level+1);
+        output->append("\"");
+        output->append(it->first);
+        output->append("\"");
+
+        output->append(":");
+
+        if(indent == true) {
+            output->append(" ");
+        }
+
+        // add value
+        if(it->second == nullptr)
         {
-            if(it->second != nullptr
-                    && it->second->getType() != typeCounter)
-            {
-                continue;
+            output->append("null");
+        }
+        else
+        {
+            // if value is string-item, then set quotes
+            if(it->second->isStringValue()) {
+                output->append("\"");
             }
 
-            if(firstPring) {
-                output->append(",");
-            }
-            firstPring = true;
+            // convert value of item into stirng
+            it->second->toString(indent, output, level+1);
 
-            // add key
-            addIndent(output, indent, level+1);
-            output->append(it->first);
-
-            output->append(":");
-
-            if(indent == true) {
-                output->append(" ");
-            }
-
-            // add value
-            if(it->second == nullptr)
-            {
-                // TODO: add unit-tests for nullptr-case
-                output->append("NULL");
-            }
-            else
-            {
-                // if value is string-item, then set quotes
-                if(it->second->isStringValue()) {
-                    output->append("\"");
-                }
-
-                // convert value of item into stirng
-                it->second->toString(indent, output, level+1);
-
-                // if value is string-item, then set quotes
-                if(it->second->isStringValue()) {
-                    output->append("\"");
-                }
+            // if value is string-item, then set quotes
+            if(it->second->isStringValue()) {
+                output->append("\"");
             }
         }
     }
@@ -1029,7 +1025,11 @@ DataArray::copy()
     DataArray* tempItem = new DataArray();
     for(uint32_t i = 0; i < m_array.size(); i++)
     {
-        tempItem->append(m_array[i]->copy());
+        if(m_array[i] == nullptr) {
+            tempItem->append(nullptr);
+        } else {
+            tempItem->append(m_array[i]->copy());
+        }
     }
     return tempItem;
 }
@@ -1061,22 +1061,25 @@ DataArray::toString(const bool indent,
             addIndent(output, indent, level+1);
         }
 
-        // check value
-        if((*it) == nullptr) {
-            continue;
+        // add value
+        if((*it) == nullptr)
+        {
+            output->append("null");
         }
+        else
+        {
+            // if value is string-item, then set quotes
+            if((*it)->isStringValue()) {
+                output->append("\"");
+            }
 
-        // if value is string-item, then set quotes
-        if((*it)->isStringValue()) {
-            output->append("\"");
-        }
+            // convert value of item into stirng
+            (*it)->toString(indent, output, level+1);
 
-        // convert value of item into stirng
-        (*it)->toString(indent, output, level+1);
-
-        // if value is string-item, then set quotes
-        if((*it)->isStringValue()) {
-            output->append("\"");
+            // if value is string-item, then set quotes
+            if((*it)->isStringValue()) {
+                output->append("\"");
+            }
         }
     }
 
@@ -1089,18 +1092,11 @@ DataArray::toString(const bool indent,
 
 /**
  * @brief add a new item to the array
- *
- * @return false, if new item-pointer is nullptr, else true
  */
-bool
+void
 DataArray::append(DataItem* item)
 {
-    if(item == nullptr) {
-        return false;
-    }
-
     m_array.push_back(item);
-    return true;
 }
 
 

--- a/src/common_items/table_item.cpp
+++ b/src/common_items/table_item.cpp
@@ -130,7 +130,8 @@ TableItem::addColumn(const std::string &internalName,
         obj->insert("outer", new DataValue(internalName));
     }
 
-    return m_header->append(obj);
+    m_header->append(obj);
+    return true;
 }
 
 /**
@@ -248,7 +249,8 @@ TableItem::addRow(const std::vector<std::string> rowContent)
                     new DataValue(rowContent.at(x)));
     }
 
-    return m_body->append(obj);
+    m_body->append(obj);
+    return true;
 }
 
 /**

--- a/tests/libKitsuneCommon/common_items/data_items_DataArray_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataArray_test.cpp
@@ -44,12 +44,13 @@ DataItems_DataArray_Test::append_test()
     DataValue intValue(42);
     DataValue floatValue(42.5f);
 
-    UNITTEST(array.append(defaultValue.copy()), true);
-    UNITTEST(array.append(stringValue.copy()), true);
-    UNITTEST(array.append(intValue.copy()), true);
-    UNITTEST(array.append(floatValue.copy()), true);
+    array.append(defaultValue.copy());
+    array.append(stringValue.copy());
+    array.append(intValue.copy());
+    array.append(floatValue.copy());
+    array.append(nullptr);
 
-    UNITTEST(array.append(nullptr), false);
+    UNITTEST(array.size(), 5);
 }
 
 /**
@@ -93,7 +94,7 @@ void
 DataItems_DataArray_Test::getSize_test()
 {
     DataArray array = initTestArray();
-    UNITTEST(array.size(), 4);
+    UNITTEST(array.size(), 5);
 }
 
 /**
@@ -107,7 +108,7 @@ DataItems_DataArray_Test::remove_test()
     UNITTEST(array.remove("2"), true);
 
     UNITTEST(array.get(1)->getInt(), 42);
-    UNITTEST(array.size(), 2);
+    UNITTEST(array.size(), 3);
 
     // negative tests
     UNITTEST(array.remove(10), false);
@@ -139,14 +140,15 @@ DataItems_DataArray_Test::toString_test()
 {
     DataArray array = initTestArray();
 
-    std::string compare = "[\"\",\"test\",42,42.500000]";
+    std::string compare = "[\"\",\"test\",42,42.500000,null]";
     UNITTEST(array.toString(), compare);
 
     compare = "[\n"
               "    \"\",\n"
               "    \"test\",\n"
               "    42,\n"
-              "    42.500000\n"
+              "    42.500000,\n"
+              "    null\n"
               "]";
     UNITTEST(array.toString(true), compare);
 }
@@ -221,6 +223,7 @@ DataItems_DataArray_Test::initTestArray()
     array.append(stringValue.copy());
     array.append(intValue.copy());
     array.append(floatValue.copy());
+    array.append(nullptr);
 
     return array;
 }

--- a/tests/libKitsuneCommon/common_items/data_items_DataMap_test.cpp
+++ b/tests/libKitsuneCommon/common_items/data_items_DataMap_test.cpp
@@ -79,7 +79,7 @@ void
 DataItems_DataMap_Test::getSize_test()
 {
     DataMap object = initTestObject();
-    UNITTEST(object.size(), 4);
+    UNITTEST(object.size(), 5);
 }
 
 /**
@@ -92,8 +92,8 @@ DataItems_DataMap_Test::remove_test()
     UNITTEST(object.remove(0), true);
     UNITTEST(object.remove("hmm"), true);
 
-    UNITTEST(object.get(1)->toString(), "42.500000");
-    UNITTEST(object.size(), 2);
+    UNITTEST(object.get(2)->toString(), "42.500000");
+    UNITTEST(object.size(), 3);
 
     // negative tests
     UNITTEST(object.remove(10), false);
@@ -125,14 +125,19 @@ DataItems_DataMap_Test::toString_test()
 {
     DataMap object = initTestObject();
 
-    std::string compare = "{asdf:\"test\",hmm:42,poi:\"\",xyz:42.500000}";
+    std::string compare = "{\"asdf\":\"test\","
+                          "\"fail\":null,"
+                          "\"hmm\":42,"
+                          "\"poi\":\"\","
+                          "\"xyz\":42.500000}";
     UNITTEST(object.toString(), compare);
 
     compare = "{\n"
-              "    asdf: \"test\",\n"
-              "    hmm: 42,\n"
-              "    poi: \"\",\n"
-              "    xyz: 42.500000\n"
+              "    \"asdf\": \"test\",\n"
+              "    \"fail\": null,\n"
+              "    \"hmm\": 42,\n"
+              "    \"poi\": \"\",\n"
+              "    \"xyz\": 42.500000\n"
               "}";
     UNITTEST(object.toString(true), compare);
 }
@@ -205,6 +210,7 @@ DataItems_DataMap_Test::insert_test()
     UNITTEST(object.insert("asdf", stringValue.copy()), true);
     UNITTEST(object.insert("hmm", intValue.copy()), true);
     UNITTEST(object.insert("xyz", floatValue.copy()), true);
+    UNITTEST(object.insert("fail", nullptr), true);
 }
 
 /**
@@ -229,11 +235,12 @@ DataItems_DataMap_Test::getKeys_test()
     DataMap object = initTestObject();
 
     std::vector<std::string> keys = object.getKeys();
-    UNITTEST(keys.size(), 4);
+    UNITTEST(keys.size(), 5);
     UNITTEST(keys.at(0), "asdf");
-    UNITTEST(keys.at(1), "hmm");
-    UNITTEST(keys.at(2), "poi");
-    UNITTEST(keys.at(3), "xyz");
+    UNITTEST(keys.at(1), "fail");
+    UNITTEST(keys.at(2), "hmm");
+    UNITTEST(keys.at(3), "poi");
+    UNITTEST(keys.at(4), "xyz");
 }
 
 /**
@@ -245,11 +252,11 @@ DataItems_DataMap_Test::getValues_test()
     DataMap object = initTestObject();
 
     std::vector<DataItem*> values = object.getValues();
-    UNITTEST(values.size(), 4);
+    UNITTEST(values.size(), 5);
     UNITTEST(values.at(0)->toString(), "test");
-    UNITTEST(values.at(1)->toString(), "42");
-    UNITTEST(values.at(2)->toString(), "");
-    UNITTEST(values.at(3)->toString(), "42.500000");
+    UNITTEST(values.at(2)->toString(), "42");
+    UNITTEST(values.at(3)->toString(), "");
+    UNITTEST(values.at(4)->toString(), "42.500000");
 }
 
 /**
@@ -264,7 +271,7 @@ DataItems_DataMap_Test::contains_test()
     UNITTEST(object.contains("hmm"), true);
     UNITTEST(object.contains("xyz"), true);
 
-    UNITTEST(object.contains("fail"), false);
+    UNITTEST(object.contains("12345"), false);
 }
 
 /**
@@ -285,6 +292,7 @@ DataItems_DataMap_Test::initTestObject()
     object.insert("asdf", stringValue.copy());
     object.insert("hmm", intValue.copy());
     object.insert("xyz", floatValue.copy());
+    object.insert("fail", nullptr);
 
     return object;
 }


### PR DESCRIPTION
The output of the toString-method was not fully json-compatible. Keys had no
quotes and there was no null-output. The null-case had some implications
in the tests and some checks, so there were many little updates necessary.