### PR TITLE
correct maxium thread-number

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Maximum thead number for thead-bindung is not hardcoded anymore
+
+
 ## [0.5.4] - 2019-09-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This is a simple buffer for binary-data. The primary advantage is the easier res
 
 *include-file:* `threading/thread.h`
 
-This class is only a collection of some thread-function like blocking and so on which I often use. This makes the creation of threads more easy for me. Additionally this class provides the ability to bind a new one of this thread to a specific cpu-thread (this feature is still a bit incomplete, because it has 4 threads as max number of threads).
+This class is only a collection of some thread-function like blocking and so on which I often use. This makes the creation of threads more easy for me. Additionally this class provides the ability to bind a new one of this thread to a specific cpu-thread.
 
 #### Tests
 

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -48,10 +48,9 @@ bool
 Thread::bindThreadToCore(const int coreId)
 {
     // precheck
-    // TODO: get max-core-number of the system
-    int num_cores = 4;
+    uint32_t num_cores = std::thread::hardware_concurrency();;
     if(coreId < 0
-            || coreId >= num_cores)
+            || static_cast<uint32_t>(coreId) >= num_cores)
     {
         return false;
     }
@@ -104,7 +103,7 @@ Thread::start()
 bool
 Thread::waitForFinish()
 {
-    // TODO: check that the thread doesn't typ to stop itself,
+    // TODO: check that the thread doesn't try to wait for himself,
     //       because it results into a deadlock
 
     // precheck
@@ -128,7 +127,7 @@ Thread::waitForFinish()
 void
 Thread::stop()
 {
-    // TODO: check that the thread doesn't typ to stop itself,
+    // TODO: check that the thread doesn't try to stop itself,
     //       because it results into a deadlock
 
     // precheck


### PR DESCRIPTION
For the feature of pinning a thread to a specific physical thread, the
maximum thread-ID was hard-coded to 4 threads. This was fixed so that
the function checks the real maxumum number of physical threads of the
system.